### PR TITLE
Edit links

### DIFF
--- a/PoW.md
+++ b/PoW.md
@@ -8,7 +8,7 @@
 
 [On Stake and Consensus](https://download.wpsoftware.net/bitcoin/pos.pdf) (Andrew Poelstra)
 
-[Proof-of-Stake Is a Defective Mechanism](https://vicentsus.org/docs/proof-of-stake.pdf) (Vicent Sus)
+[Proof-of-Stake Is a Defective Mechanism](https://eprint.iacr.org/2022/409.pdf) (Vicent Sus)
 
 [Long Live Proof-of-Work, Long Live Mining](https://www.truthcoin.info/blog/pow-and-mining) (Paul Sztorc)
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 This website has a few short domain aliases for easier sharing.
 
-* [btcco2.org](http://btcco2.org), [btcco2.com](http://btcco2.com) & [btcenergy.org](http://btcenergy.org) point to the [Energy](#energy) section.
+* [btcco2.org](http://btcco2.org), & [btcenergy.org](http://btcenergy.org) point to the [Energy](#energy) section.
 
 # Contributing
 

--- a/altcoins.md
+++ b/altcoins.md
@@ -24,7 +24,7 @@ See [Justice](#justice)
 
 [Pre-Bitcoin Literature @ Satoshi Nakamoto Institute](https://nakamotoinstitute.org/literature/)
 
-[Addressing Persisting Bitcoin Criticisms](https://www.fidelitydigitalassets.com/articles/addressing-bitcoin-criticisms)
+[Addressing Persisting Bitcoin Criticisms](https://www.fidelitydigitalassets.com/research-and-insights/addressing-persisting-bitcoin-criticisms#heading7)
 
 ### *"Bitcoin developers can increase its inflation"*
 
@@ -44,4 +44,4 @@ See [Justice](#justice)
 
 [Why Bitcoin’s Imitators Are Scams](https://tomerstrolight.medium.com/why-bitcoins-imitators-are-scams-e38fab4c78ba)
 
-Links to this topic [endthefud.org/altcoins](https://endthefud.org/altcoins) [shitcoin.review](http://shitcoin.review)
+Links to this topic [endthefud.org/altcoins](https://endthefud.org/altcoins)

--- a/books.md
+++ b/books.md
@@ -1,6 +1,6 @@
 ## Books
 
-* [The Bitcoin Standard](https://www.resistance.money/research/library/to%20be%20organised%20better/The%20Bitcoin%20Standard.pdf) (Saifedean Ammous)
+* [The Bitcoin Standard](https://saifedean.com/books/the-bitcoin-standard) (Saifedean Ammous)
 * Cryptoeconomics: [Book](https://voskuil.org/cryptoeconomics/), [Wiki](https://github.com/libbitcoin/libbitcoin-system/wiki/Cryptoeconomics) (Eric Voskuil)
 * [Thank God for Bitcoin](https://www.amazon.com/Thank-God-Bitcoin-Corruption-Redemption/dp/1641991216)
 * [The Bullish Case for Bitcoin](https://www.bullishcaseforbitcoin.com/) (Vijay Boyapati)

--- a/books.md
+++ b/books.md
@@ -1,6 +1,6 @@
 ## Books
 
-* [The Bitcoin Standard](https://saifedean.com/book/) (Saifedean Ammous)
+* [The Bitcoin Standard](https://www.resistance.money/research/library/to%20be%20organised%20better/The%20Bitcoin%20Standard.pdf) (Saifedean Ammous)
 * Cryptoeconomics: [Book](https://voskuil.org/cryptoeconomics/), [Wiki](https://github.com/libbitcoin/libbitcoin-system/wiki/Cryptoeconomics) (Eric Voskuil)
 * [Thank God for Bitcoin](https://www.amazon.com/Thank-God-Bitcoin-Corruption-Redemption/dp/1641991216)
 * [The Bullish Case for Bitcoin](https://www.bullishcaseforbitcoin.com/) (Vijay Boyapati)

--- a/energy.md
+++ b/energy.md
@@ -22,21 +22,17 @@
 
 [The Last Word on Bitcoin’s Energy Consumption](https://www.coindesk.com/the-last-word-on-bitcoins-energy-consumption) (Nic Carter)
 
-[Addressing Persisting Bitcoin Criticisms](https://www.fidelitydigitalassets.com/articles/addressing-bitcoin-criticisms) (Ria Bhutoria)
+[Addressing Persisting Bitcoin Criticisms](https://www.fidelitydigitalassets.com/research-and-insights/addressing-persisting-bitcoin-criticisms#heading4) (Ria Bhutoria)
 
 [Common Critiques #4: Bitcoin Wastes Energy](https://casebitcoin.com/critiques/bitcoin-wastes-energy) (Case Bitcoin)
 
-[The Bitcoin Mining Network: Trends, Average Creation Costs, Electricity Consumption & Sources](https://coinshares.com/research/bitcoin-mining-network-december-2019) (Christopher Bendiksen & Samuel Gibbons)
+[The Bitcoin Mining Network: Trends, Average Creation Costs, Electricity Consumption & Sources](https://coinshares.com/research/bitcoin-mining-network-2022) (Christopher Bendiksen & Samuel Gibbons)
 
 [PoW is Efficient](https://danhedl.medium.com/pow-is-efficient-aa3d442754d3) (Dan Held)
 
 [Bitcoin Miners Consume A Reasonable Amount of Energy — And It's All Worth It](https://bitcoinmagazine.com/business/op-ed-bitcoin-miners-consume-reasonable-amount-energy-and-its-all-worth-it) (Marc Bevand)
 
 [Bitcoin Mining Wastes Energy? What If That’s Good?](https://www.coindesk.com/bitcoin-mining-wastes-energy-thats-good-thing) (Michael J. Casey)
-
-[Bitcoin: A Bold American Future](https://journal.bitcoinreserve.com/bitcoin-a-bold-american-future/) (Conner Brown)
-
-[FACT CHECK: Is Bitcoin mining environmentally unfriendly?](https://blog.coinbase.com/fact-check-is-bitcoin-mining-environmentally-unfriendly-3559823af6f1) (Coinbase)
 
 [Bitcoin’s Energy Usage Isn’t a Problem. Here’s Why.](https://www.swanbitcoin.com/bitcoins-energy-usage-is-not-a-problem-heres-why-by-lyn-alden/) (behind [registration wall](https://blog.getadmiral.com/registration-wall)) (Lyn Alden)
 
@@ -94,5 +90,5 @@
 
 [Bitcoin's Energy Consumption - A shift in perspective](https://dergigi.com/2018/06/10/bitcoin-s-energy-consumption/) (Gigi)
 
-Links to this topic: [btcCO2.org](http://btcco2.org) [btcCO2.com](http://btcco2.com) [btcenergy.org](http://btcenergy.org) [endthefud.org/energy](https://endthefud.org/energy) [energy.endthefud.org](http://energy.endthefud.org)
+Links to this topic: [btcCO2.org](http://btcco2.org) [btcenergy.org](http://btcenergy.org) [endthefud.org/energy](https://endthefud.org/energy) [energy.endthefud.org](http://energy.endthefud.org)
 

--- a/governments.md
+++ b/governments.md
@@ -50,7 +50,7 @@
 
 [Shelling Out](https://nakamotoinstitute.org/shelling-out/)
 
-[The Bitcoin Standard (chapters 1-3)](https://www.resistance.money/research/library/to%20be%20organised%20better/The%20Bitcoin%20Standard.pdf)
+[The Bitcoin Standard (chapters 1-3)](https://saifedean.com/books/the-bitcoin-standard)
 
 [The Fraying of the US Global Currency Reserve System](https://www.lynalden.com/fraying-petrodollar-system/)
 

--- a/governments.md
+++ b/governments.md
@@ -29,7 +29,7 @@
 
 [Bitcoin is Not Backed by Nothing](https://nakamotoinstitute.org/mempool/bitcoin-is-not-backed-by-nothing/)
 
-[Addressing Persisting Bitcoin Criticisms](https://www.fidelitydigitalassets.com/articles/addressing-bitcoin-criticisms)
+[Addressing Persisting Bitcoin Criticisms](https://www.fidelitydigitalassets.com/research-and-insights/addressing-persisting-bitcoin-criticisms#heading6)
 
 
 ### *"Bitcoin is mined/controlled by China"*
@@ -50,7 +50,7 @@
 
 [Shelling Out](https://nakamotoinstitute.org/shelling-out/)
 
-[The Bitcoin Standard (chapters 1-3)](https://saifedean.com/book/)
+[The Bitcoin Standard (chapters 1-3)](https://www.resistance.money/research/library/to%20be%20organised%20better/The%20Bitcoin%20Standard.pdf)
 
 [The Fraying of the US Global Currency Reserve System](https://www.lynalden.com/fraying-petrodollar-system/)
 

--- a/money.md
+++ b/money.md
@@ -6,7 +6,7 @@
 
 [Misconceptions about Bitcoin](https://www.lynalden.com/misconceptions-about-bitcoin/) (Lyn Alden)
 
-[Addressing Persisting Bitcoin Criticisms](https://www.fidelitydigitalassets.com/articles/addressing-bitcoin-criticisms) (Ria Bhutoria)
+[Addressing Persisting Bitcoin Criticisms](https://www.fidelitydigitalassets.com/research-and-insights/addressing-persisting-bitcoin-criticisms#heading2) (Ria Bhutoria)
 
 
 ### *"Bitcoin is a bad medium-of-exchange"*

--- a/money.md
+++ b/money.md
@@ -22,7 +22,7 @@
 
 [Value Proposition](https://github.com/libbitcoin/libbitcoin-system/wiki/Value-Proposition)  (Eric Voskuil)
 
-[Misconceptions about Bitcoin](https://www.lynalden.com/misconceptions-about-bitcoin/) (Lyn Alden)
+[Misconceptions about Bitcoin](https://www.lynalden.com/misconceptions-about-bitcoin/) (Section 1 & 2, Lyn Alden)
 
 [How we Know Bitcoin is Not a Bubble](https://nakamotoinstitute.org/mempool/how-we-know-bitcoin-is-not-a-bubble/) (Daniel Krawisz)
 
@@ -38,7 +38,7 @@
 
 ### *"Bitcoin isn't scalable", "Can't process as many payments as Visa"*
 
-[Misconceptions about Bitcoin](https://www.lynalden.com/misconceptions-about-bitcoin/) (Lyn Alden)
+[Misconceptions about Bitcoin](https://www.lynalden.com/misconceptions-about-bitcoin/) (Section 3, Lyn Alden)
 
 
 ### *"Bitcoin's price is artificially manipulated"*


### PR DESCRIPTION
I noticed that some links redirected to a 404 - Page not found error. I have replaced these with working ones, provided I found current links.

The articles "Bitcoin: A Bold American Future" and "FACT CHECK: Is Bitcoin mining environmentally unfriendly?" from the "Energy" section can no longer be found anywhere, so I deleted them completely.

Also I added in the "Bitcoin as Money" section the sections for the "Misconceptions about Bitcoin" article, where the reader can find the specific information.